### PR TITLE
Micro batches

### DIFF
--- a/configs/oc22/is2re/base.yml
+++ b/configs/oc22/is2re/base.yml
@@ -4,10 +4,10 @@ dataset:
   train:
     src: data/oc22/is2re/train
     normalize_labels: False
-    total_energy: True
+    total_energy: False
   val:
     src: data/oc22/is2re/val_id
-    total_energy: True
+    total_energy: False
 
 logger: wandb
 

--- a/configs/oc22/s2ef/base.yml
+++ b/configs/oc22/s2ef/base.yml
@@ -4,10 +4,10 @@ dataset:
   train:
     src: data/oc22/s2ef/train
     normalize_labels: False
-    total_energy: True
+    total_energy: False
   val:
     src: data/oc22/s2ef/val_id
-    total_energy: True
+    total_energy: False
 
 logger: wandb
 

--- a/configs/oc22/s2ef/dpp.yml
+++ b/configs/oc22/s2ef/dpp.yml
@@ -3,8 +3,8 @@ includes:
 
 model:
   name: dimenetplusplus
-  hidden_channels: 85
-  out_emb_channels: 64
+  hidden_channels: 512
+  out_emb_channels: 384
   num_blocks: 3
   cutoff: 6.0
   num_radial: 6
@@ -20,7 +20,7 @@ optim:
   batch_size: 3
   eval_batch_size: 3
   eval_every: 5000
-  num_workers: 4
+  num_workers: 3
   lr_initial: 0.0001
   warmup_steps: -1 # don't warm-up the learning rate
   # warmup_factor: 0.2

--- a/configs/oc22/s2ef/dpp.yml
+++ b/configs/oc22/s2ef/dpp.yml
@@ -3,8 +3,8 @@ includes:
 
 model:
   name: dimenetplusplus
-  hidden_channels: 512
-  out_emb_channels: 384
+  hidden_channels: 85
+  out_emb_channels: 64
   num_blocks: 3
   cutoff: 6.0
   num_radial: 6
@@ -20,7 +20,7 @@ optim:
   batch_size: 3
   eval_batch_size: 3
   eval_every: 5000
-  num_workers: 3
+  num_workers: 4
   lr_initial: 0.0001
   warmup_steps: -1 # don't warm-up the learning rate
   # warmup_factor: 0.2

--- a/configs/oc22/s2ef/graphormer/graphormer_t1.yml
+++ b/configs/oc22/s2ef/graphormer/graphormer_t1.yml
@@ -12,15 +12,15 @@ model:
   dropout: 0.0
   attention_dropout: 0.1
   activation_dropout: 0.0
-  num_kernel: 128
+  num_kernel: 32
   regress_forces: True
   otf_graph: True
 
 optim:
-  batch_size: 10
-  eval_batch_size: 10
+  batch_size: 3
+  eval_batch_size: 3
   eval_every: 5000
-  num_workers: 0
+  num_workers: 4
   lr_initial: 0.0003
   warmup_steps: 10000 # don't warm-up the learning rate
   warmup_factor: 0.2

--- a/configs/oc22/s2ef/graphormer/graphormer_t1.yml
+++ b/configs/oc22/s2ef/graphormer/graphormer_t1.yml
@@ -17,8 +17,9 @@ model:
   otf_graph: True
 
 optim:
-  batch_size: 3
+  batch_size: 16
   eval_batch_size: 3
+  micro_batch_size: 3
   eval_every: 5000
   num_workers: 4
   lr_initial: 0.0003

--- a/configs/oc22/s2ef/graphormer/graphormer_t1.yml
+++ b/configs/oc22/s2ef/graphormer/graphormer_t1.yml
@@ -18,8 +18,8 @@ model:
 
 optim:
   batch_size: 16
-  eval_batch_size: 3
-  micro_batch_size: 3
+  eval_batch_size: 2
+  micro_batch_size: 2
   eval_every: 5000
   num_workers: 4
   lr_initial: 0.0003

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -348,7 +348,7 @@ class ForcesTrainer(BaseTrainer):
                 agg_o = {
                     "energy": torch.tensor([]),
                     "forces": torch.tensor([]),
-                }  # Batch output (for use in metrics computatoin)
+                }  # Batch output (for use in metrics computation)
                 # Forward, loss, backward.
                 with torch.cuda.amp.autocast(enabled=self.scaler is not None):
                     # with torch.cpu.amp.autocast(enabled=self.scaler is not None):

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -9,11 +9,13 @@ import logging
 import os
 import pathlib
 from collections import defaultdict
+from math import ceil
 from pathlib import Path
 
 import numpy as np
 import torch
 import torch_geometric
+from torch_geometric.data import Batch
 from tqdm import tqdm
 
 from ocpmodels.common import distutils
@@ -337,25 +339,44 @@ class ForcesTrainer(BaseTrainer):
 
                 # Get a batch.
                 batch = next(train_loader_iter)
-
+                # Loss normalization algorithm
+                Nu = self.config["optim"]["micro_batch_size"]
+                Nb = self.config["optim"]["batch_size"]
+                NSu = ceil(Nb / Nu)
+                u = self.split(batch[0], Nu)
+                avg_l = 0  # Batch loss (for use in metrics update)
+                agg_o = {
+                    "energy": torch.tensor([]),
+                    "forces": torch.tensor([]),
+                }  # Batch output (for use in metrics computatoin)
                 # Forward, loss, backward.
                 with torch.cuda.amp.autocast(enabled=self.scaler is not None):
                     # with torch.cpu.amp.autocast(enabled=self.scaler is not None):
-                    out = self._forward(batch)
-                    loss = self._compute_loss(out, batch)
-                loss = self.scaler.scale(loss) if self.scaler else loss
-                self._backward(loss)
+                    for i in range(NSu):
+                        out = self._forward(u[i : i + 1])
+                        agg_o["energy"] = torch.cat(
+                            [agg_o["energy"], out["energy"]]
+                        )
+                        agg_o["forces"] = torch.cat(
+                            [agg_o["forces"], out["forces"]]
+                        )
+                        loss = self._compute_loss(out, u[i : i + 1])
+                        loss_norm = loss / NSu
+                        avg_l += loss_norm.item()
+                        loss_norm.backward()
+                loss = self.scaler.scale(avg_l) if self.scaler else avg_l
+                self._update_accumulated_gradients()
                 scale = self.scaler.get_scale() if self.scaler else 1.0
 
                 # Compute metrics.
                 self.metrics = self._compute_metrics(
-                    out,
+                    agg_o,
                     batch,
                     self.evaluator,
                     self.metrics,
                 )
                 self.metrics = self.evaluator.update(
-                    "loss", loss.item() / scale, self.metrics
+                    "loss", loss / scale, self.metrics
                 )
 
                 # Log metrics.
@@ -439,6 +460,32 @@ class ForcesTrainer(BaseTrainer):
             self.val_dataset.close_db()
         if self.config.get("test_dataset", False):
             self.test_dataset.close_db()
+
+    def split(self, batch, micro_batch_size):
+        assert type(batch) == torch_geometric.data.batch.DataBatch
+        micro_batches = []
+        index = 0
+        for i in range(self.config["optim"]["batch_size"] // micro_batch_size):
+            micro_batches.append(
+                Batch.from_data_list(
+                    batch.index_select(slice(index, index + micro_batch_size))
+                )
+            )
+            index += micro_batch_size
+        if self.config["optim"]["batch_size"] % micro_batch_size:
+            micro_batches.append(
+                Batch.from_data_list(
+                    batch.index_select(
+                        slice(
+                            index,
+                            index
+                            + self.config["optim"]["batch_size"]
+                            % micro_batch_size,
+                        )
+                    )
+                )
+            )
+        return micro_batches
 
     def _forward(self, batch_list):
         # forward pass.


### PR DESCRIPTION
This is part of an effort to reduce the memory consumption of OCP models. This will allow effective training using one GPU, albeit n times slower. In a future branch, the gradient noise scale should be logged and using this information, the critical batch size should be determined. Finally, the metrics should be analyzed to ensure that no residual graphs are contained in memory. 